### PR TITLE
Handle extraneous whitespace

### DIFF
--- a/lib/parse.ts
+++ b/lib/parse.ts
@@ -3,7 +3,7 @@ import { Env } from './types';
 /**
  * @see http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html
  */
-const lineRegExp = /^([a-zA-Z_]+[a-zA-Z0-9_]*)=(.*)$/;
+const lineRegExp = /^([a-zA-Z_]+[a-zA-Z0-9_]*)\s*=\s*(.*)$/;
 
 /**
  * Accounts for CR / LF / CR+LF line breaks
@@ -15,7 +15,7 @@ export function parse(dotEnv: string): Env {
     const parsed: Env = {};
 
     for (const line of lines) {
-        const match = line.match(lineRegExp);
+        const match = line.trim().match(lineRegExp);
         if (!match) continue;
 
         const variableName = match[1];

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -38,6 +38,30 @@ describe('parse', () => {
     it('should ignore comments', () => {
         expect(parse(comment)).toEqual({});
     });
+
+    it('should parse a line with leading whitespace', () => {
+        expect(parse(ok5)).toEqual({
+            LEADING_WHITESPACE: 'cadillac'
+        })
+    })
+
+    it('should parse a line with trailing whitespace', () => {
+        expect(parse(ok6)).toEqual({
+            TRAILING_WHITESPACE: 'mercury'
+        })
+    })
+
+    it('should parse a line with extra whitespace', () => {
+        expect(parse(ok7)).toEqual({
+            EXTRA_WHITESPACE: 'pontiac'
+        })
+    })
+
+    it('should parse a line with extra ws and a string value containing ws', () => {
+        expect(parse(ok8)).toEqual({
+            EXTRA_WHITESPACE_STRING: 'thunder bird'
+        })
+    })
 });
 
 const ok1 = `
@@ -69,3 +93,18 @@ bad.identifier=true
 const comment = `
 #STRING=local
 `;
+
+const ok5 = `
+ LEADING_WHITESPACE=cadillac
+ `;
+
+const ok6 = `
+TRAILING_WHITESPACE=mercury 
+ `;
+
+const ok7 = `
+ EXTRA_WHITESPACE = pontiac
+ `
+const ok8 = `
+ EXTRA_WHITESPACE_STRING = thunder bird
+ `


### PR DESCRIPTION
Better handling of .env files containing leading, trailing and otherwise ill-placed whitespace.